### PR TITLE
fix(secu): use jQuery 3.5.1 min file

### DIFF
--- a/Dummy/src/dummy.ihtml
+++ b/Dummy/src/dummy.ihtml
@@ -13,7 +13,7 @@
 	var widgetId = "{$widgetId}";
 	var autoRefresh = "{$autoRefresh}";
 	</script>
-	<script type="text/javascript" src="../../include/common/javascript/jquery/jquery.js"></script>
+	<script type="text/javascript" src="../../include/common/javascript/jquery/jquery.min.js"></script>
 	<script type="text/javascript" src="../../include/common/javascript/jquery/jquery-ui.js"></script>
 	<script type="text/javascript" src="../../include/common/javascript/widgetUtils.js"></script>
 	<script type="text/javascript" src="src/data_js.js"></script>


### PR DESCRIPTION
## Description

Replace the jQuery path to use Centreon's minified file

**Fixes** # (MON-6573)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

